### PR TITLE
Ask DUB to build the project in the bin/ subdirectory, for compatibil…

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -6,6 +6,7 @@
 	"authors": ["Robert burner Schadek"],
 	"license": "BSD",
 	"targetType" : "executable",
+	"targetPath": "bin",
 	"importPaths": [".", "source"],
 	"sourcePaths": ["source"],
 	"dependencies": {
@@ -13,3 +14,4 @@
 	},
 	"compiler" : "dmd"
 }
+


### PR DESCRIPTION
…ity with dlangide.

Currently dlangide requires executables be in a subdirectory of the root, called bin.  I personally think that's a dlangide bug, but for now I'd like to use dlangide to work with std.xml2.

All the contributors to std.xml2 should be notified, and we may want to update .gitignore as well.
